### PR TITLE
Add missing QAction header

### DIFF
--- a/aivctrl/variousslots.cpp
+++ b/aivctrl/variousslots.cpp
@@ -1,3 +1,4 @@
+#include <QAction>
 #include "mainwindow.hpp"
 #include "ui_mainwindow.h"
 #include "aivwidgets/networkprogress.hpp"


### PR DESCRIPTION
It's required to build aivctrl on fedora 28 and possibly other systems.

Signed-off-by: Przemo Firszt <przemo@firszt.eu>